### PR TITLE
Fix for Sparc64 fuse

### DIFF
--- a/SOURCES/fuse-numa-sparc64.patch
+++ b/SOURCES/fuse-numa-sparc64.patch
@@ -1,0 +1,25 @@
+diff --git sesman/chansrv/chansrv_fuse.c sesman/chansrv/chansrv_fuse.c
+index b3499ad..5d37850 100644
+--- sesman/chansrv/chansrv_fuse.c
++++ sesman/chansrv/chansrv_fuse.c
+@@ -574,9 +574,9 @@ char buf[135168];
+             return -1;
+ 
+ #ifdef HACK
+-        fuse_session_process(g_se, buf, rval, tmpch);
++        fuse_session_process(g_se, buf, rval, tmpch, 0);
+ #else
+-        fuse_session_process(g_se, g_buffer, rval, tmpch);
++        fuse_session_process(g_se, g_buffer, rval, tmpch, 0);
+ #endif
+     }
+ 
+@@ -808,7 +808,7 @@ int xfuse_file_contents_size(int stream_id, int file_size)
+ 
+ static int xfuse_init_lib(struct fuse_args *args)
+ {
+-    if (fuse_parse_cmdline(args, &g_mount_point, 0, 0) < 0)
++    if (fuse_parse_cmdline(args, &g_mount_point, 0, 0, 0) < 0)
+     {
+         log_error("fuse_parse_cmdline() failed");
+         fuse_opt_free_args(args);

--- a/SPECS/xrdp.spec.in
+++ b/SPECS/xrdp.spec.in
@@ -20,6 +20,7 @@ Source3:	xrdp.logrotate
 
 Patch0:		xrdp-pam-auth.patch
 Patch1:		sesman.ini.patch
+Patch2:		fuse-numa-sparc64.patch
 
 # Basic dependensies
 BuildRequires:	autoconf
@@ -56,6 +57,7 @@ RDP server for Linux
 %setup -q -n %%GH_ACCOUNT%%-%%GH_PROJECT%%-%%GH_COMMIT%%
 %patch0
 %patch1 -p 1
+%patch2
 
 %build
 ./bootstrap

--- a/X11RDP-RH-Matic.sh
+++ b/X11RDP-RH-Matic.sh
@@ -45,7 +45,7 @@ SOURCE_DIR=$(rpm --eval %{_sourcedir})
 TARGETS="xrdp x11rdp"
 META_DEPENDS="dialog rpm-build rpmdevtools"
 FETCH_DEPENDS="ca-certificates git wget"
-EXTRA_SOURCE="xrdp.init xrdp.sysconfig xrdp.logrotate xrdp-pam-auth.patch buildx_patch.diff x11_file_list.patch sesman.ini.patch"
+EXTRA_SOURCE="xrdp.init xrdp.sysconfig xrdp.logrotate xrdp-pam-auth.patch buildx_patch.diff x11_file_list.patch sesman.ini.patch fuse-numa-sparc64.patch"
 XRDP_BUILD_DEPENDS="autoconf automake libtool openssl-devel pam-devel libX11-devel libXfixes-devel libXrandr-devel fuse-devel which make"
 XRDP_CONFIGURE_ARGS="--enable-fuse"
 


### PR DESCRIPTION
FUSE in Oracle Linux for SPARC[1] is patched[2] to support numa mount
option. This is a workaround to build on Oracle Linux for SPARC 1.0.

[1] https://oss.oracle.com/projects/linux-sparc/
[2] http://sourceforge.net/p/fuse/mailman/message/30786707/