### PR TITLE
Fix invalid license field

### DIFF
--- a/SPECS/xrdp.spec.in
+++ b/SPECS/xrdp.spec.in
@@ -10,7 +10,7 @@
 Summary:	Open source Remote Desktop Protocol (RDP) server
 Name:		xrdp
 Version:	%{xrdpver}+%{xrdpbranch}
-License:	Apache License 2.0
+License:	ASL 2.0
 Release:	1%{?dist}
 URL:		http://www.xrdp.org/
 Source0:	%%GH_ACCOUNT%%-%%GH_PROJECT%%-%%GH_COMMIT%%.tar.gz


### PR DESCRIPTION
There is a rpmlint warning about invalid license in License: field.

  xrdp.x86_64: W: invalid-license Apache License 2.0
  The value of the License tag was not recognized.  Known values are: "AAL",
  "Abstyles", "Adobe", "ADSL", "AFL", "Afmparse", "AGPLv1", "AGPLv3", "AGPLv3
  ...

It should be ASL 2.0 for Apache License 2.0.

ref. https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing