### PR TITLE
Do not overwrite configuration unexpectedly on update

### DIFF
--- a/SPECS/xrdp.spec.in
+++ b/SPECS/xrdp.spec.in
@@ -140,8 +140,8 @@ rm -rf %{buildroot}
 %config(noreplace) %{_sysconfdir}/pam.d/xrdp-sesman
 %config(noreplace) %{_sysconfdir}/logrotate.d/xrdp
 %config(noreplace) %{_sysconfdir}/sysconfig/xrdp
-%{_sysconfdir}/xrdp/pulse/*
-%{_sysconfdir}/xrdp/km-*.ini
+%config(noreplace) %{_sysconfdir}/xrdp/pulse/*
+%config(noreplace) %{_sysconfdir}/xrdp/km-*.ini
 %{_sysconfdir}/xrdp/*.sh
 %{_libdir}/xrdp/*
 %{_datadir}/xrdp/*


### PR DESCRIPTION
Keep configuration by config(noreplace) not to overwrite
with update RPM.

/etc/xrdp/km-*.ini and /etc/xrdp/pulse/default.pa are usually no need to
modify, but if you modified it by some reason, your configuration is
lost without this fix.