### PR TITLE
Do not install .la files

### DIFF
--- a/SPECS/xrdp.spec.in
+++ b/SPECS/xrdp.spec.in
@@ -90,6 +90,8 @@ fi
 # rsakeys.ini
 %{__rm} -f %{buildroot}%{_sysconfdir}/xrdp/rsakeys.ini
 
+find %{buildroot} -name '*.la' -delete
+
 %post
 # generate RSA key pair
 if [ ! -s %{_sysconfdir}/xrdp/rsakeys.ini ]; then

--- a/X11RDP-RH-Matic.sh
+++ b/X11RDP-RH-Matic.sh
@@ -46,7 +46,7 @@ TARGETS="xrdp x11rdp"
 META_DEPENDS="rpm-build rpmdevtools"
 FETCH_DEPENDS="ca-certificates git wget"
 EXTRA_SOURCE="xrdp.init xrdp.sysconfig xrdp.logrotate xrdp-pam-auth.patch buildx_patch.diff x11_file_list.patch sesman.ini.master.patch sesman.ini.devel.patch"
-XRDP_CONFIGURE_ARGS="--enable-fuse --enable-rfxcodec --enable-jpeg"
+XRDP_CONFIGURE_ARGS="--enable-fuse --enable-rfxcodec --enable-jpeg --disable-static"
 
 # flags
 PARALLELMAKE=true   # increase make jobs


### PR DESCRIPTION
Package guidelines says:

  Packages including libraries should exclude static libs as far as
  possible (eg by configuring with --disable-static). Static libraries
  should only be included in exceptional circumstances.

ref. https://fedoraproject.org/wiki/Packaging:Guidelines