### PR TITLE
Do not overwrite xorg.conf unexpectedly on update

### DIFF
--- a/SPECS/xorg-x11-drv-xrdp.spec.in
+++ b/SPECS/xorg-x11-drv-xrdp.spec.in
@@ -67,4 +67,4 @@ fi
 %{driverdir}/xrdpdev_drv.so
 %{inputdir}/xrdpmouse_drv.so
 %{inputdir}/xrdpkeyb_drv.so
-%{xrdpxorgconfdir}/xorg.conf
+%config(noreplace) %{xrdpxorgconfdir}/xorg.conf


### PR DESCRIPTION
Keep configuration by config(noreplace) not to overwrite with update
RPM.

If you modified it by some reason, your configuration is lost without
this fix.